### PR TITLE
Cachepot datatype

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -270,6 +270,18 @@ expr_t *newExpr_Dictionary(keyValList_t *keyVals) {
   return expr;
 }
 
+expr_t *newExpr_Cachepot() {
+  expr_t *expr = ast_emalloc(sizeof(expr_t));
+  cachepot_t *cachepot = ast_emalloc(sizeof(expr_t));
+
+  cachepot->hash = hashtable_new(CACHEPOT_STANDARD_SIZE, CACHEPOT_STANDARD_LOAD);
+
+  expr->type = EXPR_TYPE_CACHEPOT;
+  expr->cachepot = cachepot;
+
+  return expr;
+}
+
 expr_t *newExpr_Text(char *text) {
   size_t textLen = strlen(text);
   expr_t *expr = ast_emalloc(sizeof(expr_t));

--- a/src/ast.h
+++ b/src/ast.h
@@ -50,6 +50,7 @@
 #define EXPR_TYPE_INDEXER 25
 #define EXPR_TYPE_BIGINT 26
 #define EXPR_TYPE_CLASSACCESSER 27
+#define EXPR_TYPE_CACHEPOT 28
 
 #define LANG_ENTITY_DECL 1
 #define LANG_ENTITY_ARGS 2
@@ -88,6 +89,8 @@
 
 #define DICTIONARY_STANDARD_SIZE 1024
 #define DICTIONARY_STANDARD_LOAD 0.8
+#define CACHEPOT_STANDARD_SIZE 16384
+#define CACHEPOT_STANDARD_LOAD 0.8
 
 // Max number of input arguments
 #define MAX_NBR_ARGUMENTS 10
@@ -208,6 +211,10 @@ typedef struct dictionary {
   int type;
 } dictionary_t;
 
+typedef struct cachepot {
+  hashtable_t *hash;
+} cachepot_t;
+
 typedef struct expr_s {
   int type;
 
@@ -235,6 +242,7 @@ typedef struct expr_s {
     indexer_t *indexer;
     mpz_t *bigInt;
     classAccesser_t *classAccess;
+    cachepot_t *cachepot;
   };
 } expr_t;
 
@@ -367,6 +375,7 @@ expr_t *newExpr_Indexer(expr_t *left, expr_t *right, expr_t *offset);
 expr_t *newExpr_BigIntFromStr(const char *intStr);
 expr_t *newExpr_BigIntFromInt(intptr_t val);
 expr_t *newExpr_BigInt(mpz_t *n);
+expr_t *newExpr_Cachepot();
 expr_t *newClassAccesser(expr_t *classID, char *memberID);
 expr_t *newConditional(int type, expr_t *left, expr_t *right);
 
@@ -403,7 +412,8 @@ typedef enum stackvaltypes {
   TIMETYPE,
   RAWDATATYPE,
   INDEXER,
-  BIGINT
+  BIGINT,
+  CACHEPOT
 } stackvaltypes_t;
 
 typedef struct stackval {
@@ -422,6 +432,7 @@ typedef struct stackval {
     rawdata_t *rawdata;
     indexer_t *indexer;
     mpz_t *bigInt;
+    cachepot_t *cachepot;
   };
 } stackval_t;
 
@@ -570,7 +581,7 @@ typedef struct libFunction {
     intptr_t p;                                            \
     *sb = calloc(sz + 1, sizeof(stackval_t));              \
     assert(*sb != NULL);                                   \
-    p = ((intptr_t)*sb) % sizeof(stackval_t);              \
+    p = ((intptr_t) * sb) % sizeof(stackval_t);            \
     if (p != 0) {                                          \
       p = (sizeof(stackval_t) - (p % sizeof(stackval_t))); \
     }                                                      \
@@ -584,7 +595,7 @@ typedef struct libFunction {
     heapval_t hpbv;                                    \
     *hb = calloc(hz + 2, sizeof(heapval_t));           \
     assert(*hb != NULL);                               \
-    p = ((intptr_t)*hb) % sizeof(heapval_t);           \
+    p = ((intptr_t) * hb) % sizeof(heapval_t);         \
     p = (sizeof(heapval_t) - (p % sizeof(heapval_t))); \
     hpbv.sv.type = INT32TYPE;                          \
     hpbv.sv.i = (int32_t)hz;                           \
@@ -598,7 +609,7 @@ typedef struct libFunction {
   do {                                                   \
     stackval_t stackval;                                 \
     if (*sc >= *PROVIDE_CONTEXT()->stacksize) {          \
-      fprintf(stderr, "Error: Intepreter stack overflow\n\
+      fprintf(stderr, "Error: Interpreter stack overflow\n\
 Please include the script and file an error report to me here:\n    %s\n\
 This is not supposed to happen, I hope I can fix it!\n", \
               GENERAL_ERROR_ISSUE_URL);                  \
@@ -614,7 +625,7 @@ This is not supposed to happen, I hope I can fix it!\n", \
   do {                                                               \
     stackval_t stackval;                                             \
     if (*sc >= *PROVIDE_CONTEXT()->stacksize) {                      \
-      fprintf(stderr, "Error: Intepreter stack overflow\n\
+      fprintf(stderr, "Error: Interpreter stack overflow\n\
 Please include the script and file an error report to me here:\n    %s\n\
 This is not supposed to happen, I hope I can fix the intepreter!\n", \
               GENERAL_ERROR_ISSUE_URL);                              \
@@ -630,7 +641,7 @@ This is not supposed to happen, I hope I can fix the intepreter!\n", \
   do {                                                               \
     stackval_t stackval;                                             \
     if (*sc >= *PROVIDE_CONTEXT()->stacksize) {                      \
-      fprintf(stderr, "Error: Intepreter stack overflow\n\
+      fprintf(stderr, "Error: Interpreter stack overflow\n\
 Please include the script and file an error report to me here:\n    %s\n\
 This is not supposed to happen, I hope I can fix the intepreter!\n", \
               GENERAL_ERROR_ISSUE_URL);                              \
@@ -646,7 +657,7 @@ This is not supposed to happen, I hope I can fix the intepreter!\n", \
   do {                                                               \
     stackval_t stackval;                                             \
     if (*sc >= *PROVIDE_CONTEXT()->stacksize) {                      \
-      fprintf(stderr, "Error: Intepreter stack overflow\n\
+      fprintf(stderr, "Error: Interpreter stack overflow\n\
 Please include the script and file an error report to me here:\n    %s\n\
 This is not supposed to happen, I hope I can fix the intepreter!\n", \
               GENERAL_ERROR_ISSUE_URL);                              \
@@ -662,7 +673,7 @@ This is not supposed to happen, I hope I can fix the intepreter!\n", \
   do {                                                               \
     stackval_t stackval;                                             \
     if (*sc >= *PROVIDE_CONTEXT()->stacksize) {                      \
-      fprintf(stderr, "Error: Intepreter stack overflow\n\
+      fprintf(stderr, "Error: Interpreter stack overflow\n\
 Please include the script and file an error report to me here:\n    %s\n\
 This is not supposed to happen, I hope I can fix the intepreter!\n", \
               GENERAL_ERROR_ISSUE_URL);                              \
@@ -678,7 +689,7 @@ This is not supposed to happen, I hope I can fix the intepreter!\n", \
   do {                                                               \
     stackval_t stackval;                                             \
     if (*sc >= *PROVIDE_CONTEXT()->stacksize) {                      \
-      fprintf(stderr, "Error: Intepreter stack overflow\n\
+      fprintf(stderr, "Error: Interpreter stack overflow\n\
 Please include the script and file an error report to me here:\n    %s\n\
 This is not supposed to happen, I hope I can fix the intepreter!\n", \
               GENERAL_ERROR_ISSUE_URL);                              \
@@ -695,7 +706,7 @@ This is not supposed to happen, I hope I can fix the intepreter!\n", \
   do {                                                               \
     stackval_t stackval;                                             \
     if (*sc >= *PROVIDE_CONTEXT()->stacksize) {                      \
-      fprintf(stderr, "Error: Intepreter stack overflow\n\
+      fprintf(stderr, "Error: Interpreter stack overflow\n\
 Please include the script and file an error report to me here:\n    %s\n\
 This is not supposed to happen, I hope I can fix the intepreter!\n", \
               GENERAL_ERROR_ISSUE_URL);                              \
@@ -712,7 +723,7 @@ This is not supposed to happen, I hope I can fix the intepreter!\n", \
   do {                                                               \
     stackval_t stackval;                                             \
     if (*sc >= *PROVIDE_CONTEXT()->stacksize) {                      \
-      fprintf(stderr, "Error: Intepreter stack overflow\n\
+      fprintf(stderr, "Error: Interpreter stack overflow\n\
 Please include the script and file an error report to me here:\n    %s\n\
 This is not supposed to happen, I hope I can fix the intepreter!\n", \
               GENERAL_ERROR_ISSUE_URL);                              \
@@ -729,7 +740,7 @@ This is not supposed to happen, I hope I can fix the intepreter!\n", \
   do {                                                               \
     stackval_t stackval;                                             \
     if (*sc >= *PROVIDE_CONTEXT()->stacksize) {                      \
-      fprintf(stderr, "Error: Intepreter stack overflow\n\
+      fprintf(stderr, "Error: Interpreter stack overflow\n\
 Please include the script and file an error report to me here:\n    %s\n\
 This is not supposed to happen, I hope I can fix the intepreter!\n", \
               GENERAL_ERROR_ISSUE_URL);                              \
@@ -746,7 +757,7 @@ This is not supposed to happen, I hope I can fix the intepreter!\n", \
   do {                                                               \
     stackval_t stackval;                                             \
     if (*sc >= *PROVIDE_CONTEXT()->stacksize) {                      \
-      fprintf(stderr, "Error: Intepreter stack overflow\n\
+      fprintf(stderr, "Error: Interpreter stack overflow\n\
 Please include the script and file an error report to me here:\n    %s\n\
 This is not supposed to happen, I hope I can fix the intepreter!\n", \
               GENERAL_ERROR_ISSUE_URL);                              \
@@ -763,7 +774,7 @@ This is not supposed to happen, I hope I can fix the intepreter!\n", \
   do {                                                               \
     stackval_t stackval;                                             \
     if (*sc >= *PROVIDE_CONTEXT()->stacksize) {                      \
-      fprintf(stderr, "Error: Intepreter stack overflow\n\
+      fprintf(stderr, "Error: Interpreter stack overflow\n\
 Please include the script and file an error report to me here:\n    %s\n\
 This is not supposed to happen, I hope I can fix the intepreter!\n", \
               GENERAL_ERROR_ISSUE_URL);                              \
@@ -780,7 +791,7 @@ This is not supposed to happen, I hope I can fix the intepreter!\n", \
   do {                                                               \
     stackval_t stackval;                                             \
     if (*sc >= *PROVIDE_CONTEXT()->stacksize) {                      \
-      fprintf(stderr, "Error: Intepreter stack overflow\n\
+      fprintf(stderr, "Error: Interpreter stack overflow\n\
 Please include the script and file an error report to me here:\n    %s\n\
 This is not supposed to happen, I hope I can fix the intepreter!\n", \
               GENERAL_ERROR_ISSUE_URL);                              \
@@ -797,7 +808,7 @@ This is not supposed to happen, I hope I can fix the intepreter!\n", \
   do {                                                               \
     stackval_t stackval;                                             \
     if (*sc >= *PROVIDE_CONTEXT()->stacksize) {                      \
-      fprintf(stderr, "Error: Intepreter stack overflow\n\
+      fprintf(stderr, "Error: Interpreter stack overflow\n\
 Please include the script and file an error report to me here:\n    %s\n\
 This is not supposed to happen, I hope I can fix the intepreter!\n", \
               GENERAL_ERROR_ISSUE_URL);                              \
@@ -810,10 +821,27 @@ This is not supposed to happen, I hope I can fix the intepreter!\n", \
     *sc = *sc + 1;                                                   \
   } while (0)
 
+#define PUSH_CACHEPOT(a, sp, sc)                                     \
+  do {                                                               \
+    stackval_t stackval;                                             \
+    if (*sc >= *PROVIDE_CONTEXT()->stacksize) {                      \
+      fprintf(stderr, "Error: Interpreter stack overflow\n\
+Please include the script and file an error report to me here:\n    %s\n\
+This is not supposed to happen, I hope I can fix the intepreter!\n", \
+              GENERAL_ERROR_ISSUE_URL);                              \
+      exit(1);                                                       \
+    }                                                                \
+    stackval.type = CACHEPOT;                                        \
+    stackval.cachepot = a;                                           \
+    **((stackval_t **)sp) = stackval;                                \
+    *((stackval_t **)sp) += 1;                                       \
+    *sc = *sc + 1;                                                   \
+  } while (0)
+
 #define POP_VAL(a, sp, sc)                                           \
   do {                                                               \
     if (*sc == 0) {                                                  \
-      fprintf(stderr, "Error: Intepreter stack corruption\n\
+      fprintf(stderr, "Error: Interpreter stack corruption\n\
 Please include the script and file an error report to me here:\n    %s\n\
 This is not supposed to happen, I hope I can fix the intepreter!\n", \
               GENERAL_ERROR_ISSUE_URL);                              \
@@ -856,7 +884,7 @@ extern void releaseContext(void *);
     if (i == size) {                                                                       \
       fprintf(stderr, "Error: Heap full (size: %d)\n", size);                              \
       fprintf(stderr, "       The heap size can be increased with the -ah flag\n");        \
-      fprintf(stderr, "       See: ric -h for more information\n");                        \
+      fprintf(stderr, "       For more information, see: ric -h\n");                       \
       exit(1);                                                                             \
     }                                                                                      \
     releaseContext(PROVIDE_CONTEXT()->syncCtx);                                            \

--- a/src/ast.h
+++ b/src/ast.h
@@ -581,7 +581,7 @@ typedef struct libFunction {
     intptr_t p;                                            \
     *sb = calloc(sz + 1, sizeof(stackval_t));              \
     assert(*sb != NULL);                                   \
-    p = ((intptr_t) * sb) % sizeof(stackval_t);            \
+    p = ((intptr_t)*sb) % sizeof(stackval_t);              \
     if (p != 0) {                                          \
       p = (sizeof(stackval_t) - (p % sizeof(stackval_t))); \
     }                                                      \
@@ -595,7 +595,7 @@ typedef struct libFunction {
     heapval_t hpbv;                                    \
     *hb = calloc(hz + 2, sizeof(heapval_t));           \
     assert(*hb != NULL);                               \
-    p = ((intptr_t) * hb) % sizeof(heapval_t);         \
+    p = ((intptr_t)*hb) % sizeof(heapval_t);           \
     p = (sizeof(heapval_t) - (p % sizeof(heapval_t))); \
     hpbv.sv.type = INT32TYPE;                          \
     hpbv.sv.i = (int32_t)hz;                           \

--- a/src/eval.c
+++ b/src/eval.c
@@ -1065,7 +1065,7 @@ void evaluate_expression(expr_t *expr, EXPRESSION_PARAMS()) {
               break;
             }
             default: {
-              fprintf(stderr, "%s.%d index error: datatype the does not support conditioning.\n",
+              fprintf(stderr, "%s.%d index error: datatype that does not support conditioning.\n",
                       ((statement_t *)stmt)->file, ((statement_t *)stmt)->line);
               if (!*interactive) {
                 exit(1);
@@ -1110,9 +1110,10 @@ void evaluate_expression(expr_t *expr, EXPRESSION_PARAMS()) {
         POP_VAL(&sv, sp, sc);
 
         if (sv.type != VECTORTYPE && sv.type != DICTTYPE && sv.type != TEXT
-            && sv.type != RAWDATATYPE) {
-          fprintf(stderr, "%s.%d index error: '%s' is a datatype the does not support indexing.\n",
-                  ((statement_t *)stmt)->file, ((statement_t *)stmt)->line, id->id.id);
+            && sv.type != RAWDATATYPE && sv.type != CACHEPOT) {
+          fprintf(stderr,
+                  "%s.%d index error: '%s' is a datatype (%d) that does not support indexing.\n",
+                  ((statement_t *)stmt)->file, ((statement_t *)stmt)->line, id->id.id, sv.type);
           if (!*interactive) {
             exit(1);
           }

--- a/src/hashtable.c
+++ b/src/hashtable.c
@@ -207,6 +207,27 @@ void *hashtable_get(hashtable_t *hashtable, void *ctx, const char *key) {
   return NULL;
 }
 
+void *hashtable_get_key_ptr(hashtable_t *hashtable, void *ctx, const char *key) {
+  if (hashtable == NULL) return NULL;
+
+  int index = hashtable_hash(hashtable, key);
+  if (hashtable->table[index] == NULL) {
+    return NULL;
+  }
+
+  getContext(ctx);
+  struct key_val_pair *p = hashtable->table[index];
+  while (p != NULL) {
+    if (strcmp(p->key, key) == 0) {
+      releaseContext(ctx);
+      return p->key;
+    }
+    p = p->next;
+  }
+  releaseContext(ctx);
+  return NULL;
+}
+
 void print_table_as_chars(hashtable_t *hashtable) {
   int i = 0;
   int size = hashtable->size;

--- a/src/hashtable.h
+++ b/src/hashtable.h
@@ -41,6 +41,7 @@ void free_hashtable_table(hashtable_t *hash);
 void hashtable_rehash(hashtable_t *);
 void hashtable_free(hashtable_t *);
 void *hashtable_get(hashtable_t *, void *, const char *);
+void *hashtable_get_key_ptr(hashtable_t *, void *, const char *);
 int hashtable_hash(hashtable_t *, const char *);
 void hashtable_put(hashtable_t *, void *, char *, void *);
 void print_table_as_chars(hashtable_t *);

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -107,7 +107,13 @@ interpret_state_t interpret_statements_(void *stmt, PROVIDE_CONTEXT_ARGS(), args
               free(e);
             }
 
-            ALLOC_HEAP(&sv, hp, &hvp, &heapUpdated);
+            /* In case we are dealing with a cachepot */
+            if (sv.type == CACHEPOT) {
+              hvp = ast_emalloc(sizeof(heapval_t));
+              hvp->sv = sv;
+            } else {
+              ALLOC_HEAP(&sv, hp, &hvp, &heapUpdated);
+            }
 
             /* Check if the variable is to be put in the class namespace */
             if (classCtx != NULL) {
@@ -317,7 +323,6 @@ interpret_state_t interpret_statements_(void *stmt, PROVIDE_CONTEXT_ARGS(), args
                   free(key_ptr);
                   free_expression(p);
                   free(p);
-                  printf("match..\n");
                 }
                 hashtable_put(cachepot->hash, PROVIDE_CONTEXT()->syncCtx, key, newExp);
               } break;

--- a/src/interpret.c
+++ b/src/interpret.c
@@ -20,7 +20,6 @@ interpret_state_t interpret_statements_(void *stmt, PROVIDE_CONTEXT_ARGS(), args
 
   while (stmt != NULL) {
     eval = (entity_eval_t *)stmt;
-
     switch (eval->entity) {
       case LANG_ENTITY_DECL:
       case LANG_ENTITY_FUNCDECL:
@@ -71,7 +70,6 @@ interpret_state_t interpret_statements_(void *stmt, PROVIDE_CONTEXT_ARGS(), args
         heapval_t *hvp = NULL;
         declaration_t *decl = ((statement_t *)stmt)->content;
         id = decl->id;
-
         switch (id->type) {
           case EXPR_TYPE_ID: {
             int heapUpdated;
@@ -79,7 +77,6 @@ interpret_state_t interpret_statements_(void *stmt, PROVIDE_CONTEXT_ARGS(), args
             heapval_t *classCheck = NULL;
             char *idStr = id->id.id;
             int stop = 0;
-
             /* Evaluating the expression among global variables */
             evaluate_expression(decl->val, EXPRESSION_ARGS());
             POP_VAL(&sv, sp, sc);
@@ -146,7 +143,6 @@ interpret_state_t interpret_statements_(void *stmt, PROVIDE_CONTEXT_ARGS(), args
             expr_t *index = id->vecIdx->index;
 
             stackval_t sv;
-
             evaluate_expression(vecid, EXPRESSION_ARGS());
             POP_VAL(&sv, sp, sc);
 
@@ -291,6 +287,39 @@ interpret_state_t interpret_statements_(void *stmt, PROVIDE_CONTEXT_ARGS(), args
                   text[arrayIndex + q] = newAddition[q];
                   q++;
                 }
+              } break;
+              case CACHEPOT: {
+                cachepot_t *cachepot = sv.cachepot;
+                expr_t *newExp;
+                expr_t *p = NULL;
+                char *key = NULL;
+                /* Assigning a cachepot */
+                evaluate_expression(index, EXPRESSION_ARGS());
+                POP_VAL(&sv, sp, sc);
+                if (sv.type != TEXT) {
+                  fprintf(stderr, "index error: Must provide a string as index\n");
+                  exit(1);
+                }
+                key = ast_emalloc(strlen(sv.t) + 1);
+                snprintf(key, strlen(sv.t) + 1, "%s", sv.t);
+
+                /* Evaluating the expression among global variables */
+                evaluate_expression(decl->val, EXPRESSION_ARGS());
+                POP_VAL(&sv, sp, sc);
+
+                newExp = stackval_to_expression(&sv, EXPR_NO_ALLOC, EXPRESSION_ARGS());
+                /* check if overwrite */
+                p = hashtable_get(cachepot->hash, PROVIDE_CONTEXT()->syncCtx, key);
+                if (p != NULL) {
+                  // Free the overwritten data
+                  char *key_ptr =
+                      hashtable_get_key_ptr(cachepot->hash, PROVIDE_CONTEXT()->syncCtx, key);
+                  free(key_ptr);
+                  free_expression(p);
+                  free(p);
+                  printf("match..\n");
+                }
+                hashtable_put(cachepot->hash, PROVIDE_CONTEXT()->syncCtx, key, newExp);
               } break;
               default: {
                 fprintf(stderr, "index error: '%s' is not an indexable object.\n", id->id.id);

--- a/src/lib.c
+++ b/src/lib.c
@@ -37,6 +37,7 @@ libFunction_t ric_library[] = {
     DECLARE_LIB_FUNCTION("sum", 1, ric_sum),
     DECLARE_LIB_FUNCTION("sort", 1, ric_sort),
     DECLARE_LIB_FUNCTION("join", 2, ric_join),
+    DECLARE_LIB_FUNCTION("cachepot", 0, ric_cachepot),
     // libjson
     DECLARE_LIB_FUNCTION("jsonLoad", 1, ric_json_load),
     DECLARE_LIB_FUNCTION("jsonConvert", 1, ric_json_convert),

--- a/src/library/libstd.c
+++ b/src/library/libstd.c
@@ -626,6 +626,9 @@ int ric_printf(LIBRARY_PARAMS()) {
       print_dictionary(stv.dict, EXPRESSION_ARGS());
       break;
     }
+    case CACHEPOT: {
+      print_cachepot(stv.cachepot, EXPRESSION_ARGS());
+    } break;
     case VECTORTYPE: {
       print_vector(stv.vec, EXPRESSION_ARGS());
     } break;
@@ -642,6 +645,7 @@ int ric_printf(LIBRARY_PARAMS()) {
       exit(1);
     } break;
   }
+  fflush(stdout);
 
   return 0;
 }

--- a/src/library/libstd.c
+++ b/src/library/libstd.c
@@ -488,6 +488,11 @@ int ric_print(LIBRARY_PARAMS()) {
       printf("\n");
       break;
     }
+    case CACHEPOT: {
+      print_cachepot(stv.cachepot, EXPRESSION_ARGS());
+      printf("\n");
+      break;
+    }
     case FUNCPTRTYPE:
       printf("<Function: '%s'>\n", stv.func->id.id);
       break;
@@ -965,25 +970,14 @@ int ric_contains(LIBRARY_PARAMS()) {
   } else if (argDict != NULL) {
     /* Search in a dictionary */
     hashtable_t *hash = argDict->hash;
-    int hashSize = hash->size;
-    struct key_val_pair *ptr;
-    int i = 0;
 
     if (searchForInt) {
       /* all keys are strings */
       result = 0;
     } else {
-      while (i < hashSize && result == 0) {
-        ptr = hash->table[i];
-        while (ptr != NULL) {
-          /* Check if match */
-          if (strcmp((char *)ptr->key, containText) == 0) {
-            result = 1;
-            break;
-          }
-          ptr = ptr->next;
-        }
-        i++;
+      heapval_t *hvp = hashtable_get(hash, PROVIDE_CONTEXT()->syncCtx, containText);
+      if (hvp != NULL) {
+        result = 1;
       }
     }
   } else if (argText != NULL) {
@@ -1491,12 +1485,12 @@ int ric_join(LIBRARY_PARAMS()) {
     if (first_iteration) {
       // first iteration
       bytesToWrite = strlen(stv.t);
-      if ( bytesToWrite > 0 ) {
+      if (bytesToWrite > 0) {
         snprintf(&outChars[i], bytesToWrite + 1, "%s", stv.t);
       }
     } else {
       bytesToWrite = strlen(stv.t) + joinArgLen;
-      if ( strlen(stv.t) > 0 ) {
+      if (strlen(stv.t) > 0) {
         snprintf(&outChars[i], bytesToWrite + 1, "%s%s", joinArg, stv.t);
       } else {
         snprintf(&outChars[i], bytesToWrite + 1, "%s", joinArg);
@@ -1514,5 +1508,17 @@ int ric_join(LIBRARY_PARAMS()) {
   /* Pushing the parsed value */
   PUSH_STRING(stv.t, sp, sc);
 
+  return 0;
+}
+
+int ric_cachepot(LIBRARY_PARAMS()) {
+  void *sp = PROVIDE_CONTEXT()->sp;
+  size_t *sc = PROVIDE_CONTEXT()->sc;
+  expr_t *e = newExpr_Cachepot();
+
+  cachepot_t *cachepot = e->cachepot;
+  free(e);
+
+  PUSH_CACHEPOT(cachepot, sp, sc);
   return 0;
 }

--- a/src/library/libstd.c
+++ b/src/library/libstd.c
@@ -897,6 +897,7 @@ int ric_contains(LIBRARY_PARAMS()) {
   vector_t *argVec = NULL;
   dictionary_t *argDict = NULL;
   char *argText = NULL;
+  cachepot_t *cachepot = NULL;
   char *containText = NULL;
   int32_t containInt = 0;
   int32_t result = 0;
@@ -916,6 +917,9 @@ int ric_contains(LIBRARY_PARAMS()) {
       break;
     case TEXT:
       argText = stv.t;
+      break;
+    case CACHEPOT:
+      cachepot = stv.cachepot;
       break;
     default: {
       fprintf(stderr,
@@ -977,6 +981,19 @@ int ric_contains(LIBRARY_PARAMS()) {
     } else {
       heapval_t *hvp = hashtable_get(hash, PROVIDE_CONTEXT()->syncCtx, containText);
       if (hvp != NULL) {
+        result = 1;
+      }
+    }
+  } else if (cachepot != NULL) {
+    /* Search in a cachepot */
+    hashtable_t *hash = cachepot->hash;
+
+    if (searchForInt) {
+      /* all keys are strings */
+      result = 0;
+    } else {
+      expr_t *e = hashtable_get(hash, PROVIDE_CONTEXT()->syncCtx, containText);
+      if (e != NULL) {
         result = 1;
       }
     }

--- a/src/library/libstd.h
+++ b/src/library/libstd.h
@@ -38,5 +38,6 @@ int ric_print_env(LIBRARY_PARAMS());
 int ric_sum(LIBRARY_PARAMS());
 int ric_sort(LIBRARY_PARAMS());
 int ric_join(LIBRARY_PARAMS());
+int ric_cachepot(LIBRARY_PARAMS());
 
 #endif

--- a/src/library/libstring.c
+++ b/src/library/libstring.c
@@ -155,7 +155,7 @@ int ric_split(LIBRARY_PARAMS()) {
 
   snprintf(buffer, strlen(arg1) + 2, "%s", arg1);
 
-  if ( strcmp(arg1, arg2) == 0 ) {
+  if (strcmp(arg1, arg2) == 0) {
     /* Special case */
     special_case = 1;
   }
@@ -177,7 +177,7 @@ int ric_split(LIBRARY_PARAMS()) {
     /* Take the remaining part also */
     expr_t *e;
     argsList_t *a;
-    if ( ! special_case ) {
+    if (!special_case) {
       e = newExpr_Text(buffer + offset);
       a = newArgument(e, vecContent);
       vecContent = a;

--- a/src/print.c
+++ b/src/print.c
@@ -230,14 +230,12 @@ int print_cachepot(cachepot_t *cachepot, EXPRESSION_PARAMS()) {
   }
 
   keyCountTotal = keyCount;
-
   if (keyCountTotal > 0) {
     printf("{");
     keyCount = 0;
     i = 0;
     while (i < size) {
-      heapval_t *hpv;
-      stackval_t sv;
+      expr_t *e;
       ptr = hash->table[i];
 
       if (ptr == NULL) {
@@ -246,49 +244,8 @@ int print_cachepot(cachepot_t *cachepot, EXPRESSION_PARAMS()) {
       }
 
       printf("%s'%s' : ", (keyCount > 0 ? ", " : ""), ptr->key);
-      hpv = ptr->data;
-      sv = hpv->sv;
-
-      switch (sv.type) {
-        case INT32TYPE: {
-          printf("%" PRIi32 "", sv.i);
-        } break;
-        case DOUBLETYPE: {
-          printf("%lf", sv.d);
-        } break;
-        case BIGINT: {
-          char buf[128];
-          char *c = NULL;
-
-          c = mpz_get_str(buf, 10, *sv.bigInt);
-          printf("%s\n", c);
-        } break;
-        case TEXT: {
-          printf("'%s'", sv.t);
-        } break;
-        case POINTERTYPE: {
-          printf("<Pointer: %" PRIxPTR ">", sv.p);
-        } break;
-        case FUNCPTRTYPE: {
-          functionDef_t *funcDec = sv.func;
-          printf("<FuncPointer: '%s'>", funcDec->id.id);
-        } break;
-        case LIBFUNCPTRTYPE: {
-          libFunction_t *libFunc = sv.libfunc;
-          printf("<LibFuncPointer: '%s'>", libFunc->libFuncName);
-        } break;
-        case VECTORTYPE: {
-          print_vector(sv.vec, EXPRESSION_ARGS());
-        } break;
-        case DICTTYPE: {
-          print_dictionary(sv.dict, EXPRESSION_ARGS());
-        } break;
-        case CACHEPOT: {
-          print_cachepot(sv.cachepot, EXPRESSION_ARGS());
-        } break;
-        default:
-          break;
-      }
+      e = ptr->data;
+      print_expr(e);
 
       keyCount++;
       i++;

--- a/src/print.c
+++ b/src/print.c
@@ -208,6 +208,99 @@ void print_indents(int indent) {
   }
 }
 
+int print_cachepot(cachepot_t *cachepot, EXPRESSION_PARAMS()) {
+  hashtable_t *hash = cachepot->hash;
+  // dictionary_t *newDict = NULL;
+  int size;
+  int i;
+  int keyCount = 0;
+  int keyCountTotal = 0;
+  struct key_val_pair *ptr;
+
+  size = hash->size;
+
+  i = 0;
+  while (i < size) {
+    ptr = hash->table[i];
+    while (ptr != NULL) {
+      keyCount++;
+      ptr = ptr->next;
+    }
+    i++;
+  }
+
+  keyCountTotal = keyCount;
+
+  if (keyCountTotal > 0) {
+    printf("{");
+    keyCount = 0;
+    i = 0;
+    while (i < size) {
+      heapval_t *hpv;
+      stackval_t sv;
+      ptr = hash->table[i];
+
+      if (ptr == NULL) {
+        ++i;
+        continue;
+      }
+
+      printf("%s'%s' : ", (keyCount > 0 ? ", " : ""), ptr->key);
+      hpv = ptr->data;
+      sv = hpv->sv;
+
+      switch (sv.type) {
+        case INT32TYPE: {
+          printf("%" PRIi32 "", sv.i);
+        } break;
+        case DOUBLETYPE: {
+          printf("%lf", sv.d);
+        } break;
+        case BIGINT: {
+          char buf[128];
+          char *c = NULL;
+
+          c = mpz_get_str(buf, 10, *sv.bigInt);
+          printf("%s\n", c);
+        } break;
+        case TEXT: {
+          printf("'%s'", sv.t);
+        } break;
+        case POINTERTYPE: {
+          printf("<Pointer: %" PRIxPTR ">", sv.p);
+        } break;
+        case FUNCPTRTYPE: {
+          functionDef_t *funcDec = sv.func;
+          printf("<FuncPointer: '%s'>", funcDec->id.id);
+        } break;
+        case LIBFUNCPTRTYPE: {
+          libFunction_t *libFunc = sv.libfunc;
+          printf("<LibFuncPointer: '%s'>", libFunc->libFuncName);
+        } break;
+        case VECTORTYPE: {
+          print_vector(sv.vec, EXPRESSION_ARGS());
+        } break;
+        case DICTTYPE: {
+          print_dictionary(sv.dict, EXPRESSION_ARGS());
+        } break;
+        case CACHEPOT: {
+          print_cachepot(sv.cachepot, EXPRESSION_ARGS());
+        } break;
+        default:
+          break;
+      }
+
+      keyCount++;
+      i++;
+    }
+    printf("}");
+  } else {
+    printf("{}");
+  }
+
+  return 0;
+}
+
 int print_dictionary(dictionary_t *dict, EXPRESSION_PARAMS()) {
   hashtable_t *hash = dict->hash;
   // dictionary_t *newDict = NULL;
@@ -273,6 +366,9 @@ int print_dictionary(dictionary_t *dict, EXPRESSION_PARAMS()) {
         } break;
         case DICTTYPE: {
           print_dictionary(sv.dict, EXPRESSION_ARGS());
+        } break;
+        case CACHEPOT: {
+          print_cachepot(sv.cachepot, EXPRESSION_ARGS());
         } break;
         default:
           break;
@@ -350,6 +446,9 @@ int print_dictionary(dictionary_t *dict, EXPRESSION_PARAMS()) {
         } break;
         case DICTTYPE: {
           print_dictionary(sv.dict, EXPRESSION_ARGS());
+        } break;
+        case CACHEPOT: {
+          print_cachepot(sv.cachepot, EXPRESSION_ARGS());
         } break;
         default:
           break;
@@ -506,10 +605,144 @@ void print_expr(expr_t *expr) {
     case EXPR_TYPE_DICT:
       printf("<Dictionary>");
       break;
+    case EXPR_TYPE_CACHEPOT:
+      printf("<Cachepot>");
+      break;
     case EXPR_TYPE_EMPTY:
     default:
       break;
   }
+}
+
+int snprint_cachepot(char **buf, size_t *bufSize, size_t *pos, cachepot_t *cachepot,
+                     EXPRESSION_PARAMS()) {
+  hashtable_t *hash = cachepot->hash;
+  int size;
+  int i;
+  int keyCount = 0;
+  int keyCountTotal = 0;
+  struct key_val_pair *ptr;
+
+  if (*buf == NULL) {
+    const size_t startSize = 128;
+    *buf = ast_emalloc(startSize);
+    *bufSize = startSize;
+    *pos = 0;
+  }
+
+  size = hash->size;
+
+  i = 0;
+  while (i < size) {
+    ptr = hash->table[i];
+    while (ptr != NULL) {
+      keyCount++;
+      ptr = ptr->next;
+    }
+    i++;
+  }
+
+  keyCountTotal = keyCount;
+
+  if (keyCountTotal > 0) {
+
+    check_buf_size(buf, bufSize, pos, 1);
+    snprintf(&(*buf)[*pos], (*bufSize - *pos), "%s", "{");
+    *pos = *pos + 1;
+
+    keyCount = 0;
+    i = 0;
+    while (i < size) {
+      char tmpBuf[256];
+      size_t tmpLen;
+      heapval_t *hpv;
+      stackval_t sv;
+      ptr = hash->table[i];
+
+      if (ptr == NULL) {
+        ++i;
+        continue;
+      }
+
+      snprintf(tmpBuf, sizeof(tmpBuf), "%s\"%s\" : ", (keyCount > 0 ? ", " : ""), ptr->key);
+      tmpLen = strlen(tmpBuf);
+
+      check_buf_size(buf, bufSize, pos, tmpLen);
+      snprintf(&(*buf)[*pos], (*bufSize - *pos), "%s", tmpBuf);
+      *pos += tmpLen;
+
+      hpv = ptr->data;
+      sv = hpv->sv;
+
+      tmpLen = 0;
+
+      switch (sv.type) {
+        case INT32TYPE: {
+          snprintf(tmpBuf, sizeof(tmpBuf), "%" PRIi32 "", sv.i);
+          tmpLen = strlen(tmpBuf);
+        } break;
+        case BIGINT: {
+          char buf[128];
+          char *c = NULL;
+
+          c = mpz_get_str(buf, 10, *sv.bigInt);
+          snprintf(tmpBuf, sizeof(tmpBuf), "%s", c);
+        } break;
+        case DOUBLETYPE: {
+          snprintf(tmpBuf, sizeof(tmpBuf), "%lf", sv.d);
+          tmpLen = strlen(tmpBuf);
+        } break;
+        case TEXT: {
+          snprintf(tmpBuf, sizeof(tmpBuf), "\"%s\"", sv.t);
+          tmpLen = strlen(tmpBuf);
+        } break;
+        case POINTERTYPE: {
+          snprintf(tmpBuf, sizeof(tmpBuf), "<Pointer: %" PRIxPTR ">", sv.p);
+          tmpLen = strlen(tmpBuf);
+        } break;
+        case FUNCPTRTYPE: {
+          functionDef_t *funcDec = sv.func;
+          snprintf(tmpBuf, sizeof(tmpBuf), "<Function: '%s'>", funcDec->id.id);
+          tmpLen = strlen(tmpBuf);
+        } break;
+        case LIBFUNCPTRTYPE: {
+          libFunction_t *libFunc = sv.libfunc;
+          snprintf(tmpBuf, sizeof(tmpBuf), "<Function: '%s'>", libFunc->libFuncName);
+          tmpLen = strlen(tmpBuf);
+        } break;
+        case VECTORTYPE: {
+          snprint_vector(buf, bufSize, pos, sv.vec, EXPRESSION_ARGS());
+        } break;
+        case DICTTYPE: {
+          snprint_dictionary(buf, bufSize, pos, sv.dict, EXPRESSION_ARGS());
+        } break;
+        case CACHEPOT: {
+          snprint_cachepot(buf, bufSize, pos, sv.cachepot, EXPRESSION_ARGS());
+        } break;
+        default:
+          break;
+      }
+
+      if (tmpLen > 0) {
+        check_buf_size(buf, bufSize, pos, tmpLen);
+        snprintf(&(*buf)[*pos], (*bufSize - *pos), "%s", tmpBuf);
+
+        *pos += tmpLen;
+      }
+
+      keyCount++;
+      i++;
+    }
+    check_buf_size(buf, bufSize, pos, 1);
+    snprintf(&(*buf)[*pos], (*bufSize - *pos), "%s", "}");
+    *pos = *pos + 1;
+  } else {
+    check_buf_size(buf, bufSize, pos, 2);
+    snprintf(&(*buf)[*pos], (*bufSize - *pos), "%s", "{}");
+    *pos += 2;
+  }
+
+  return 0;
 }
 
 int snprint_dictionary(char **buf, size_t *bufSize, size_t *pos, dictionary_t *dict,
@@ -602,6 +835,9 @@ int snprint_dictionary(char **buf, size_t *bufSize, size_t *pos, dictionary_t *d
         } break;
         case DICTTYPE: {
           snprint_dictionary(buf, bufSize, pos, sv.dict, EXPRESSION_ARGS());
+        } break;
+        case CACHEPOT: {
+          snprint_cachepot(buf, bufSize, pos, sv.cachepot, EXPRESSION_ARGS());
         } break;
         default:
           break;
@@ -708,6 +944,9 @@ int snprint_dictionary(char **buf, size_t *bufSize, size_t *pos, dictionary_t *d
         } break;
         case DICTTYPE: {
           snprint_dictionary(buf, bufSize, pos, sv.dict, EXPRESSION_ARGS());
+        } break;
+        case CACHEPOT: {
+          snprint_cachepot(buf, bufSize, pos, sv.cachepot, EXPRESSION_ARGS());
         } break;
         default:
           break;
@@ -821,6 +1060,9 @@ int snprint_vector(char **buf, size_t *bufSize, size_t *pos, vector_t *vec, EXPR
         break;
       case DICTTYPE:
         snprint_dictionary(buf, bufSize, pos, sv.dict, EXPRESSION_ARGS());
+        break;
+      case CACHEPOT:
+        snprint_cachepot(buf, bufSize, pos, sv.cachepot, EXPRESSION_ARGS());
         break;
       default:
         break;

--- a/src/print.h
+++ b/src/print.h
@@ -15,10 +15,12 @@ int print_args(argsList_t *args);
 int print_vector(vector_t *vec, EXPRESSION_PARAMS());
 int snprint_vector(char **buf, size_t *bufSize, size_t *pos, vector_t *vec, EXPRESSION_PARAMS());
 
+int print_cachepot(cachepot_t *dict, EXPRESSION_PARAMS());
 int print_dictionary(dictionary_t *dict, EXPRESSION_PARAMS());
 int snprint_dictionary(char **buf, size_t *bufSize, size_t *pos, dictionary_t *dict,
                        EXPRESSION_PARAMS());
-
+int snprint_cachepot(char **buf, size_t *bufSize, size_t *pos, cachepot_t *dict,
+                     EXPRESSION_PARAMS());
 void locals_print(locals_stack_t *stack);
 
 #endif


### PR DESCRIPTION
Adding a datatype needed for performance sake.
It is a dictionary that only stores references to data.
I might change the default dictionary in the future, to work like cachepot.
But there are some memory safety concerns I have that I need to evaluate.
An example of cachepot in action can be found in the ric-script advent of code repo here:

https://github.com/Ricardicus/ric-script-advent-of-code/blob/master/2023/12.ric